### PR TITLE
feat: DB マイグレーション・シーダーの作成

### DIFF
--- a/src/database/migrations/2026_02_22_043636_create_categories_table.php
+++ b/src/database/migrations/2026_02_22_043636_create_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/src/database/migrations/2026_02_22_043636_create_posts_table.php
+++ b/src/database/migrations/2026_02_22_043636_create_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('title');
+            $table->text('body');
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('category_id');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/src/database/migrations/2026_02_22_043637_create_comments_table.php
+++ b/src/database/migrations/2026_02_22_043637_create_comments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamps();
+
+            $table->index('post_id');
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/src/database/migrations/2026_02_22_043637_create_likes_table.php
+++ b/src/database/migrations/2026_02_22_043637_create_likes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('likes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['post_id', 'user_id']);
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('likes');
+    }
+};

--- a/src/database/seeders/CategorySeeder.php
+++ b/src/database/seeders/CategorySeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categories = ['雑談', '質問', '報告', 'その他'];
+
+        foreach ($categories as $name) {
+            DB::table('categories')->insert([
+                'name'       => $name,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -3,23 +3,31 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    use WithoutModelEvents;
-
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // パスワードは全員 "password"（開発用）
+        User::factory()->create([
+            'name'  => 'テストユーザーA',
+            'email' => 'user-a@example.com',
+        ]);
 
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name'  => 'テストユーザーB',
+            'email' => 'user-b@example.com',
+        ]);
+
+        User::factory()->create([
+            'name'  => 'テストユーザーC',
+            'email' => 'user-c@example.com',
+        ]);
+
+        $this->call([
+            CategorySeeder::class,
+            PostSeeder::class,
         ]);
     }
 }

--- a/src/database/seeders/PostSeeder.php
+++ b/src/database/seeders/PostSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PostSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $userIds = DB::table('users')->pluck('id');
+
+        $posts = [
+            ['user_id' => $userIds[0], 'category_id' => 1, 'title' => 'はじめまして！', 'body' => "このサービスに登録しました。よろしくお願いします！"],
+            ['user_id' => $userIds[1], 'category_id' => 1, 'title' => '近所のおすすめカフェ', 'body' => "駅前に新しいカフェがオープンしました。ラテがとても美味しいです。"],
+            ['user_id' => $userIds[0], 'category_id' => 2, 'title' => 'Laravelのルーティングについて', 'body' => "Route::resource と Route::apiResource の違いを教えていただけますか？"],
+            ['user_id' => $userIds[2], 'category_id' => 2, 'title' => 'Dockerのポート設定', 'body' => "docker-compose.yml で \"3307:3306\" と書いた場合、ホストからは 3307 で接続するという理解で合っていますか？"],
+            ['user_id' => $userIds[1], 'category_id' => 3, 'title' => 'v1.0リリースしました', 'body' => "長らく開発してきたサービスをついにリリースしました！フィードバックお待ちしております。"],
+            ['user_id' => $userIds[2], 'category_id' => 4, 'title' => '今日の作業ログ', 'body' => "マイグレーション・シーダーの実装が完了しました。次はモデルとポリシーを実装します。"],
+            ['user_id' => $userIds[0], 'category_id' => null, 'title' => 'カテゴリなしの投稿サンプル', 'body' => "このように category_id が NULL の投稿は、カテゴリフィルタを使わない場合のみ一覧に表示されます。"],
+        ];
+
+        foreach ($posts as $post) {
+            DB::table('posts')->insert([
+                'user_id'     => $post['user_id'],
+                'category_id' => $post['category_id'],
+                'title'       => $post['title'],
+                'body'        => $post['body'],
+                'created_at'  => now(),
+                'updated_at'  => now(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

掲示板アプリに必要な4テーブルのマイグレーションと、開発用サンプルデータのシーダーを実装しました。

## 追加テーブル

| テーブル | 主な用途 |
|---|---|
| `categories` | 投稿カテゴリ（雑談/質問/報告/その他） |
| `posts` | 投稿本体（タイトル・本文・投稿者・カテゴリ） |
| `comments` | 投稿へのコメント |
| `likes` | 投稿へのいいね（1ユーザー1いいね） |

## なぜこのように実装したか

### `foreignId()` + `constrained()` の組み合わせ

```php
$table->foreignId('user_id')->constrained()->cascadeOnDelete();
```

Laravel の `foreignId('user_id')` は `BIGINT UNSIGNED` のカラムを作ります。  
`constrained()` を続けることで、カラム名の命名規則（`user_id` → `users.id`）から自動的に外部キー制約を追加します。  
`cascadeOnDelete()` はユーザーが削除された時に関連レコードも連鎖削除する設定です。

posts の `category_id` だけ `nullOnDelete()` にしているのは、カテゴリを削除しても投稿自体は残したいからです（カテゴリなし状態になる）。

### `likes` の複合ユニーク制約

```php
$table->unique(['post_id', 'user_id']);
```

同一ユーザーが同一投稿に2回いいねするのを DB レベルで防ぎます。アプリ側のバリデーションだけでは並行リクエストで重複が起きる可能性があるため、DB の制約で確実に防ぎます。

### `index()` を明示的に追加した理由

外部キー制約を貼ると MySQL は自動的にインデックスを作ることが多いですが、`created_at` のように外部キーでないカラムへのソート用インデックスは自動では作られません。  
`posts.created_at` に `index()` を追加したのは、新着順（`ORDER BY created_at DESC`）のクエリを高速化するためです。

### シーダーの設計

- **ユーザー3名**：後のいいね・コメント実装時に「他ユーザーからのアクション」をテストできるよう複数用意
- **カテゴリなし投稿を1件含める**：カテゴリフィルタの「カテゴリなしは非表示」挙動を確認するため

## 動作確認

```bash
make fresh  # または docker compose exec app php artisan migrate:fresh --seed
```

実行後、Sequel Ace で各テーブルのレコードを確認済み。

## 次のPR

`feat/models-and-policies` — Eloquent モデル（リレーション定義）+ Policy（認可）+ FormRequest（バリデーション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)