### PR TITLE
feat: モデル・ポリシー・フォームリクエストの実装

### DIFF
--- a/src/app/Http/Requests/CommentRequest.php
+++ b/src/app/Http/Requests/CommentRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/src/app/Http/Requests/PostRequest.php
+++ b/src/app/Http/Requests/PostRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title'       => ['required', 'string', 'max:255'],
+            'body'        => ['required', 'string'],
+            'category_id' => ['nullable', 'integer', 'exists:categories,id'],
+        ];
+    }
+}

--- a/src/app/Models/Category.php
+++ b/src/app/Models/Category.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    protected $fillable = ['name'];
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    protected $fillable = ['body'];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/Like.php
+++ b/src/app/Models/Like.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Like extends Model
+{
+    protected $fillable = ['post_id', 'user_id'];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Post extends Model
+{
+    protected $fillable = ['category_id', 'title', 'body'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function likes(): HasMany
+    {
+        return $this->hasMany(Like::class);
+    }
+}

--- a/src/app/Policies/CommentPolicy.php
+++ b/src/app/Policies/CommentPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+
+class CommentPolicy
+{
+    public function update(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id;
+    }
+
+    public function delete(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id;
+    }
+}

--- a/src/app/Policies/PostPolicy.php
+++ b/src/app/Policies/PostPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+}


### PR DESCRIPTION
## 概要

Eloquent モデルのリレーション定義、Policy による認可、FormRequest によるバリデーションを実装しました。

## 変更ファイル

| ファイル | 役割 |
|---|---|
| `Models/Category.php` | categories テーブルのモデル |
| `Models/Post.php` | posts テーブルのモデル（リレーション含む） |
| `Models/Comment.php` | comments テーブルのモデル |
| `Models/Like.php` | likes テーブルのモデル |
| `Policies/PostPolicy.php` | 投稿の編集・削除権限 |
| `Policies/CommentPolicy.php` | コメントの編集・削除権限 |
| `Requests/PostRequest.php` | 投稿フォームのバリデーション |
| `Requests/CommentRequest.php` | コメントフォームのバリデーション |

## なぜこのように実装したか

### $fillable に user_id を含めない理由（Post・Comment）

```php
// Post モデル
protected $fillable = ['category_id', 'title', 'body'];
```

`user_id` を `$fillable` に含めると、悪意あるユーザーがフォームに `user_id` を仕込んで他人の名義で投稿できてしまいます。`user_id` はコントローラー側で `auth()->id()` を明示的にセットする方針にします。

`Like` だけは `['post_id', 'user_id']` 両方を含めていますが、Like の作成はコントローラーで完全制御するため問題ありません。

### Policy の実装（「自分のデータのみ」）

```php
public function update(User $user, Post $post): bool
{
    return $user->id === $post->user_id;
}
```

ログイン中のユーザー ID と投稿の作成者 ID が一致する場合のみ `true` を返します。コントローラーで `$this->authorize('update', $post)` と呼ぶだけで、この判定が自動的に走り、不一致なら 403 を返します。

生成された雛形には `restore` / `forceDelete` などのメソッドもありましたが、今回使わないため削除してシンプルにしています。

### FormRequest の authorize() を true にする理由

```php
public function authorize(): bool
{
    return true;  // 認証チェックは middleware('auth') に任せる
}
```

デフォルトは `false`（全員拒否）です。認証済みかどうかのチェックはルーティングの `middleware('auth')` で行うため、FormRequest 側では `true` にして全員通過させています。FormRequest の `authorize()` でも認可チェックはできますが、Policy と二重管理になるため役割を分けています。

### exists:categories,id バリデーション

```php
'category_id' => ['nullable', 'integer', 'exists:categories,id'],
```

`nullable` でカテゴリなしを許容しつつ、値が送られてきた場合は `categories` テーブルに実在する id かどうかを DB で確認します。存在しない id を受け付けると FK 制約違反になるため、アプリ側でも事前にはじきます。

## 次のPR

`feat/post-crud` — PostController（7メソッド）+ ルーティング + 投稿 CRUD の Blade ビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)