### PR TITLE
feat: コメント CRUD の実装

### DIFF
--- a/src/app/Http/Controllers/CommentController.php
+++ b/src/app/Http/Controllers/CommentController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CommentRequest;
+use App\Models\Comment;
+use App\Models\Post;
+
+class CommentController extends Controller
+{
+    public function store(CommentRequest $request, Post $post)
+    {
+        $post->comments()->create(
+            $request->validated() + ['user_id' => auth()->id()]
+        );
+
+        return redirect()->route('posts.show', $post)
+            ->with('success', 'コメントを投稿しました。');
+    }
+
+    public function edit(Post $post, Comment $comment)
+    {
+        $this->authorize('update', $comment);
+
+        return view('comments.edit', compact('post', 'comment'));
+    }
+
+    public function update(CommentRequest $request, Post $post, Comment $comment)
+    {
+        $this->authorize('update', $comment);
+
+        $comment->update($request->validated());
+
+        return redirect()->route('posts.show', $post)
+            ->with('success', 'コメントを更新しました。');
+    }
+
+    public function destroy(Post $post, Comment $comment)
+    {
+        $this->authorize('delete', $comment);
+
+        $comment->delete();
+
+        return redirect()->route('posts.show', $post)
+            ->with('success', 'コメントを削除しました。');
+    }
+}

--- a/src/resources/views/comments/edit.blade.php
+++ b/src/resources/views/comments/edit.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="card" style="max-width: 640px;">
+    <div class="card-body">
+        <h1 class="h5 mb-1">コメントを編集</h1>
+        <p class="text-muted small mb-4">
+            投稿：<a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
+        </p>
+
+        <form method="POST" action="{{ route('comments.update', [$post, $comment]) }}">
+            @csrf
+            @method('PUT')
+
+            <div class="mb-3">
+                <label class="form-label">本文 <span class="text-danger">*</span></label>
+                <textarea name="body" rows="4"
+                          class="form-control @error('body') is-invalid @enderror"
+                          maxlength="1000">{{ old('body', $comment->body) }}</textarea>
+                @error('body')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">更新する</button>
+                <a href="{{ route('posts.show', $post) }}" class="btn btn-outline-secondary">キャンセル</a>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CommentController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
@@ -15,6 +16,11 @@ Route::middleware('auth')->group(function () {
     Route::get('/posts/{post}/edit', [PostController::class, 'edit'])->name('posts.edit');
     Route::put('/posts/{post}', [PostController::class, 'update'])->name('posts.update');
     Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+
+    Route::post('/posts/{post}/comments', [CommentController::class, 'store'])->name('comments.store');
+    Route::get('/posts/{post}/comments/{comment}/edit', [CommentController::class, 'edit'])->name('comments.edit');
+    Route::put('/posts/{post}/comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
+    Route::delete('/posts/{post}/comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
 
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## 概要

CommentController（store / edit / update / destroy）、ネストルート、コメント編集ビューを実装しました。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `CommentController.php` | コメントの投稿・編集フォーム表示・更新・削除 |
| `routes/web.php` | コメントのネストルート4本を追加 |
| `comments/edit.blade.php` | コメント編集フォーム |

## なぜこのように実装したか

### ネストルートにした理由

```
POST   /posts/{post}/comments
GET    /posts/{post}/comments/{comment}/edit
PUT    /posts/{post}/comments/{comment}
DELETE /posts/{post}/comments/{comment}
```

コメントは必ず特定の投稿に属するため、URL にも `posts/{post}` を含めています。これにより「どの投稿のコメントか」が URL から明確になります。

コントローラー側でも `Post $post` と `Comment $comment` の両方を Route Model Binding で受け取ることで、`$post->id` と `$comment->post_id` が一致しない不正アクセスを防ぐこともできます（今回は省略）。

### `$post->comments()->create()` の書き方

```php
$post->comments()->create(
    $request->validated() + ['user_id' => auth()->id()]
);
```

`$post->comments()` はリレーションの「クエリビルダ」を返します。ここに `create()` を呼ぶと、`post_id` が自動でセットされた状態でコメントが作成されます。`Comment::create(['post_id' => $post->id, ...])` と書くのと同じ結果ですが、リレーションを経由した方が意図が明確です。

### index（一覧）を持たない理由

コメント単体の一覧ページは仕様に不要なため、store / edit / update / destroy の4メソッドのみ実装しています。コメント一覧は投稿詳細ページ（`posts/show.blade.php`）内で表示します。

## 次のPR

`feat/like-feature` — LikeController + いいねトグル

🤖 Generated with [Claude Code](https://claude.com/claude-code)