### PR TITLE
feat: いいね機能の実装

### DIFF
--- a/src/app/Http/Controllers/LikeController.php
+++ b/src/app/Http/Controllers/LikeController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+
+class LikeController extends Controller
+{
+    public function toggle(Post $post)
+    {
+        $userId = auth()->id();
+
+        $liked = $post->likes()->where('user_id', $userId)->exists();
+
+        if ($liked) {
+            $post->likes()->where('user_id', $userId)->delete();
+        } else {
+            $post->likes()->create(['user_id' => $userId]);
+        }
+
+        return redirect()->route('posts.show', $post);
+    }
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\LikeController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
@@ -21,6 +22,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/posts/{post}/comments/{comment}/edit', [CommentController::class, 'edit'])->name('comments.edit');
     Route::put('/posts/{post}/comments/{comment}', [CommentController::class, 'update'])->name('comments.update');
     Route::delete('/posts/{post}/comments/{comment}', [CommentController::class, 'destroy'])->name('comments.destroy');
+
+    Route::post('/posts/{post}/likes', [LikeController::class, 'toggle'])->name('likes.toggle');
 
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## 概要

LikeController::toggle() でいいねの追加/取り消しをトグル実装しました。ビューは PR #5 の `posts/show.blade.php` に既に組み込み済みです。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `LikeController.php` | toggle メソッド（いいね追加/取り消し） |
| `routes/web.php` | `POST /posts/{post}/likes` ルート追加 |

## なぜこのように実装したか

### トグルのロジック

```php
$liked = $post->likes()->where('user_id', $userId)->exists();

if ($liked) {
    $post->likes()->where('user_id', $userId)->delete();
} else {
    $post->likes()->create(['user_id' => $userId]);
}
```

「既にいいねしているか」を `exists()` で確認し、していれば削除、していなければ作成します。シンプルな if/else で意図が明確です。

### DB の UNIQUE 制約との関係

likes テーブルには `unique(['post_id', 'user_id'])` の複合ユニーク制約があります（PR #3 で実装）。アプリ側の `exists()` チェックで通常は重複しませんが、万が一並行リクエストが来た場合でも DB 制約が最終的な砦として機能します。

### POST メソッドを使う理由

いいねは「状態を変更する操作」なので GET ではなく POST を使います。GET は副作用のない参照操作に使うのが HTTP の慣例です。ブラウザの「戻る」ボタンや検索エンジンのクローラーが誤って実行してしまうのも防げます。

## 次のPR

これで全機能が揃いました。動作確認用に `make fresh` でデータをリセットして一通り操作してみてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)