### PR TITLE
feat: デザインをモダンなスタイルにリファクタリング

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -1,0 +1,152 @@
+/* ===========================
+   Custom Design — 掲示板
+   =========================== */
+
+:root {
+    --bs-primary:       #4f46e5;
+    --bs-primary-rgb:   79, 70, 229;
+    --bs-link-color:    #4f46e5;
+    --bs-link-hover-color: #4338ca;
+    --accent:           #4f46e5;
+    --accent-hover:     #4338ca;
+}
+
+/* ---------- Base ---------- */
+body {
+    font-family: 'Inter', 'Noto Sans JP', -apple-system, sans-serif;
+    background-color: #f4f4f8;
+    color: #1d1d1f;
+}
+
+/* ---------- Navbar ---------- */
+.app-navbar {
+    background: #ffffff;
+    border-bottom: 1px solid rgba(0, 0, 0, .07);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, .04);
+}
+.app-navbar .navbar-brand {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--accent) !important;
+    letter-spacing: -0.3px;
+}
+.app-navbar .nav-user {
+    font-size: .85rem;
+    color: #6b7280;
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+    border-radius: 8px;
+    font-weight: 500;
+    letter-spacing: .01em;
+}
+.btn-primary {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+.btn-outline-primary {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+.btn-outline-primary:hover {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+
+/* ---------- Cards ---------- */
+.card {
+    border: 1px solid rgba(0, 0, 0, .07);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .06);
+    transition: box-shadow .18s ease, transform .18s ease;
+}
+.card-hoverable:hover {
+    box-shadow: 0 6px 20px rgba(0, 0, 0, .1);
+    transform: translateY(-1px);
+}
+
+/* ---------- Forms ---------- */
+.form-control,
+.form-select {
+    border-radius: 8px;
+    border-color: #d1d5db;
+    font-size: .93rem;
+}
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 0.2rem rgba(79, 70, 229, .18);
+}
+.form-label {
+    font-weight: 500;
+    font-size: .88rem;
+    color: #374151;
+    margin-bottom: .35rem;
+}
+
+/* ---------- Alerts ---------- */
+.alert {
+    border: none;
+    border-radius: 10px;
+    font-size: .9rem;
+}
+.alert-success {
+    background-color: #d1fae5;
+    color: #065f46;
+}
+.alert-danger {
+    background-color: #fee2e2;
+    color: #991b1b;
+}
+.alert-info {
+    background-color: #e0e7ff;
+    color: #3730a3;
+}
+
+/* ---------- Badge ---------- */
+.badge.bg-secondary {
+    background-color: #e5e7eb !important;
+    color: #4b5563;
+    font-weight: 500;
+    border-radius: 6px;
+}
+
+/* ---------- Pagination ---------- */
+.pagination .page-link {
+    border-radius: 8px !important;
+    margin: 0 2px;
+    color: var(--accent);
+    border-color: #e5e7eb;
+}
+.pagination .page-item.active .page-link {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+
+/* ---------- Guest layout ---------- */
+.guest-bg {
+    background: linear-gradient(140deg, #eef2ff 0%, #f4f4f8 60%);
+}
+.guest-card {
+    border: none !important;
+    border-radius: 16px !important;
+    box-shadow: 0 8px 32px rgba(79, 70, 229, .1) !important;
+}
+.guest-brand {
+    font-weight: 700;
+    font-size: 1.4rem;
+    color: var(--accent);
+    letter-spacing: -0.5px;
+    text-decoration: none;
+}
+
+/* ---------- Misc ---------- */
+a { color: var(--accent); }
+a:hover { color: var(--accent-hover); }
+hr { border-color: #e5e7eb; }

--- a/src/resources/views/auth/confirm-password.blade.php
+++ b/src/resources/views/auth/confirm-password.blade.php
@@ -1,27 +1,24 @@
 <x-guest-layout>
-    <div class="mb-4 text-sm text-gray-600">
-        {{ __('This is a secure area of the application. Please confirm your password before continuing.') }}
-    </div>
+    <h5 class="fw-bold mb-2">パスワードの確認</h5>
+    <p class="text-muted small mb-4">
+        セキュリティ保護されたエリアです。続行する前にパスワードを確認してください。
+    </p>
 
     <form method="POST" action="{{ route('password.confirm') }}">
         @csrf
 
-        <!-- Password -->
-        <div>
-            <x-input-label for="password" :value="__('Password')" />
-
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="current-password" />
-
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+        <div class="mb-4">
+            <label for="password" class="form-label">パスワード</label>
+            <input id="password" type="password" name="password"
+                   class="form-control @error('password') is-invalid @enderror"
+                   required autocomplete="current-password">
+            @error('password')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
         </div>
 
-        <div class="flex justify-end mt-4">
-            <x-primary-button>
-                {{ __('Confirm') }}
-            </x-primary-button>
+        <div class="d-flex justify-content-end">
+            <button type="submit" class="btn btn-primary px-4">確認する</button>
         </div>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/forgot-password.blade.php
+++ b/src/resources/views/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <h5 class="mb-3">パスワードをお忘れの方</h5>
+    <h5 class="fw-bold mb-2">パスワードをお忘れの方</h5>
     <p class="text-muted small mb-4">
         メールアドレスを入力すると、パスワード再設定用のリンクをお送りします。
     </p>
@@ -11,7 +11,7 @@
     <form method="POST" action="{{ route('password.email') }}">
         @csrf
 
-        <div class="mb-3">
+        <div class="mb-4">
             <label for="email" class="form-label">メールアドレス</label>
             <input id="email" type="email" name="email"
                    class="form-control @error('email') is-invalid @enderror"
@@ -21,9 +21,10 @@
             @enderror
         </div>
 
-        <div class="d-flex justify-content-between align-items-center">
-            <a href="{{ route('login') }}" class="small">ログインに戻る</a>
-            <button type="submit" class="btn btn-primary">リセットリンクを送信</button>
-        </div>
+        <button type="submit" class="btn btn-primary w-100">リセットリンクを送信</button>
+
+        <p class="text-center small mt-3 mb-0">
+            <a href="{{ route('login') }}">ログインに戻る</a>
+        </p>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -3,7 +3,7 @@
         <div class="alert alert-success mb-3">{{ session('status') }}</div>
     @endif
 
-    <h5 class="mb-4">ログイン</h5>
+    <h5 class="fw-bold mb-4">ログイン</h5>
 
     <form method="POST" action="{{ route('login') }}">
         @csrf
@@ -28,21 +28,18 @@
             @enderror
         </div>
 
-        <div class="mb-3 form-check">
+        <div class="mb-4 form-check">
             <input id="remember_me" type="checkbox" name="remember" class="form-check-input">
-            <label for="remember_me" class="form-check-label">ログイン状態を保持する</label>
+            <label for="remember_me" class="form-check-label small">ログイン状態を保持する</label>
         </div>
 
-        <div class="d-flex justify-content-between align-items-center">
+        <button type="submit" class="btn btn-primary w-100">ログイン</button>
+
+        <div class="d-flex justify-content-between align-items-center mt-3">
             @if (Route::has('password.request'))
                 <a href="{{ route('password.request') }}" class="small">パスワードをお忘れですか？</a>
             @endif
-            <button type="submit" class="btn btn-primary">ログイン</button>
+            <a href="{{ route('register') }}" class="small">新規登録はこちら</a>
         </div>
-
-        <hr>
-        <p class="text-center small mb-0">
-            アカウントをお持ちでない方は<a href="{{ route('register') }}">新規登録</a>
-        </p>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <h5 class="mb-4">新規登録</h5>
+    <h5 class="fw-bold mb-4">新規登録</h5>
 
     <form method="POST" action="{{ route('register') }}">
         @csrf
@@ -34,7 +34,7 @@
             @enderror
         </div>
 
-        <div class="mb-3">
+        <div class="mb-4">
             <label for="password_confirmation" class="form-label">パスワード（確認）</label>
             <input id="password_confirmation" type="password" name="password_confirmation"
                    class="form-control @error('password_confirmation') is-invalid @enderror"
@@ -44,9 +44,10 @@
             @enderror
         </div>
 
-        <div class="d-flex justify-content-between align-items-center">
-            <a href="{{ route('login') }}" class="small">既にアカウントをお持ちの方</a>
-            <button type="submit" class="btn btn-primary">登録する</button>
-        </div>
+        <button type="submit" class="btn btn-primary w-100">登録する</button>
+
+        <p class="text-center small mt-3 mb-0">
+            すでにアカウントをお持ちの方は<a href="{{ route('login') }}">ログイン</a>
+        </p>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/registration-otp.blade.php
+++ b/src/resources/views/auth/registration-otp.blade.php
@@ -1,9 +1,12 @@
 <x-guest-layout>
-    <h5 class="mb-3">メールアドレスの確認</h5>
-    <p class="text-muted small mb-4">
-        登録したメールアドレスに6桁の確認コードを送信しました。<br>
-        コードを入力して登録を完了してください。（10分以内に入力してください）
-    </p>
+    <div class="text-center mb-4">
+        <div class="fs-2 mb-2">📬</div>
+        <h5 class="fw-bold mb-1">確認コードを入力</h5>
+        <p class="text-muted small mb-0">
+            登録したメールアドレスに6桁のコードを送信しました。<br>
+            10分以内に入力してください。
+        </p>
+    </div>
 
     @if ($errors->has('otp') || $errors->has('email') || $errors->has('token'))
         <div class="alert alert-danger mb-3">
@@ -19,7 +22,7 @@
                 id="otp"
                 type="text"
                 name="otp"
-                class="form-control form-control-lg text-center @error('otp') is-invalid @enderror"
+                class="form-control form-control-lg text-center fw-bold ls-4 @error('otp') is-invalid @enderror"
                 inputmode="numeric"
                 maxlength="6"
                 pattern="[0-9]{6}"
@@ -27,10 +30,9 @@
                 autocomplete="one-time-code"
                 autofocus
                 required
+                style="letter-spacing: .4em; font-size: 1.5rem;"
             >
         </div>
-        <div class="d-grid">
-            <button type="submit" class="btn btn-primary">確認する</button>
-        </div>
+        <button type="submit" class="btn btn-primary w-100">確認する</button>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/reset-password.blade.php
+++ b/src/resources/views/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <h5 class="mb-4">パスワードの再設定</h5>
+    <h5 class="fw-bold mb-4">パスワードの再設定</h5>
 
     <form method="POST" action="{{ route('password.store') }}">
         @csrf
@@ -26,7 +26,7 @@
             @enderror
         </div>
 
-        <div class="mb-3">
+        <div class="mb-4">
             <label for="password_confirmation" class="form-label">新しいパスワード（確認）</label>
             <input id="password_confirmation" type="password" name="password_confirmation"
                    class="form-control @error('password_confirmation') is-invalid @enderror"
@@ -36,8 +36,6 @@
             @enderror
         </div>
 
-        <div class="d-flex justify-content-end">
-            <button type="submit" class="btn btn-primary">パスワードを再設定する</button>
-        </div>
+        <button type="submit" class="btn btn-primary w-100">パスワードを再設定する</button>
     </form>
 </x-guest-layout>

--- a/src/resources/views/auth/verify-email.blade.php
+++ b/src/resources/views/auth/verify-email.blade.php
@@ -1,25 +1,26 @@
 <x-guest-layout>
-    <h5 class="mb-3">メールアドレスの確認</h5>
-    <p class="text-muted small mb-4">
-        ご登録ありがとうございます。ご登録のメールアドレスに確認リンクを送信しました。
-        リンクをクリックして認証を完了してください。
-    </p>
+    <div class="text-center mb-4">
+        <div class="fs-2 mb-2">✉️</div>
+        <h5 class="fw-bold mb-1">メールアドレスを確認してください</h5>
+        <p class="text-muted small mb-0">
+            ご登録のメールアドレスに確認リンクを送信しました。<br>
+            リンクをクリックして認証を完了してください。
+        </p>
+    </div>
 
     @if (session('status') == 'verification-link-sent')
-        <div class="alert alert-success mb-3">
+        <div class="alert alert-success mb-4">
             確認メールを再送信しました。
         </div>
     @endif
 
-    <div class="d-flex justify-content-between align-items-center">
-        <form method="POST" action="{{ route('verification.send') }}">
-            @csrf
-            <button type="submit" class="btn btn-primary btn-sm">確認メールを再送信</button>
-        </form>
+    <form method="POST" action="{{ route('verification.send') }}">
+        @csrf
+        <button type="submit" class="btn btn-primary w-100">確認メールを再送信</button>
+    </form>
 
-        <form method="POST" action="{{ route('logout') }}">
-            @csrf
-            <button type="submit" class="btn btn-link btn-sm text-muted">ログアウト</button>
-        </form>
-    </div>
+    <form method="POST" action="{{ route('logout') }}" class="mt-3 text-center">
+        @csrf
+        <button type="submit" class="btn btn-link btn-sm text-muted">ログアウト</button>
+    </form>
 </x-guest-layout>

--- a/src/resources/views/comments/edit.blade.php
+++ b/src/resources/views/comments/edit.blade.php
@@ -1,32 +1,36 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="card" style="max-width: 640px;">
-    <div class="card-body">
-        <h1 class="h5 mb-1">コメントを編集</h1>
-        <p class="text-muted small mb-4">
-            投稿：<a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
-        </p>
+<div class="row justify-content-center">
+    <div class="col-lg-7">
+        <div class="card">
+            <div class="card-body p-4 p-md-5">
+                <h1 class="h5 fw-bold mb-1">コメントを編集</h1>
+                <p class="text-muted small mb-4">
+                    投稿：<a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
+                </p>
 
-        <form method="POST" action="{{ route('comments.update', [$post, $comment]) }}">
-            @csrf
-            @method('PUT')
+                <form method="POST" action="{{ route('comments.update', [$post, $comment]) }}">
+                    @csrf
+                    @method('PUT')
 
-            <div class="mb-3">
-                <label class="form-label">本文 <span class="text-danger">*</span></label>
-                <textarea name="body" rows="4"
-                          class="form-control @error('body') is-invalid @enderror"
-                          maxlength="1000">{{ old('body', $comment->body) }}</textarea>
-                @error('body')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
+                    <div class="mb-4">
+                        <label class="form-label">本文 <span class="text-danger">*</span></label>
+                        <textarea name="body" rows="5"
+                                  class="form-control @error('body') is-invalid @enderror"
+                                  maxlength="1000">{{ old('body', $comment->body) }}</textarea>
+                        @error('body')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary px-4">更新する</button>
+                        <a href="{{ route('posts.show', $post) }}" class="btn btn-outline-secondary">キャンセル</a>
+                    </div>
+                </form>
             </div>
-
-            <div class="d-flex gap-2">
-                <button type="submit" class="btn btn-primary">更新する</button>
-                <a href="{{ route('posts.show', $post) }}" class="btn btn-outline-secondary">キャンセル</a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
 @endsection

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -6,36 +6,39 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name', '掲示板') }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/app.css" rel="stylesheet">
 </head>
-<body class="bg-light">
+<body>
 
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+<nav class="navbar navbar-expand-lg sticky-top app-navbar">
     <div class="container">
         <a class="navbar-brand" href="{{ route('posts.index') }}">掲示板</a>
         <div class="ms-auto d-flex align-items-center gap-2">
             @auth
-                <span class="text-white-50 small">{{ auth()->user()->name }}</span>
+                <span class="nav-user">{{ auth()->user()->name }}</span>
                 <form method="POST" action="{{ route('logout') }}" class="m-0">
                     @csrf
-                    <button class="btn btn-outline-light btn-sm">ログアウト</button>
+                    <button class="btn btn-outline-secondary btn-sm">ログアウト</button>
                 </form>
             @else
-                <a href="{{ route('login') }}" class="btn btn-outline-light btn-sm">ログイン</a>
-                <a href="{{ route('register') }}" class="btn btn-light btn-sm">新規登録</a>
+                <a href="{{ route('login') }}" class="btn btn-outline-secondary btn-sm">ログイン</a>
+                <a href="{{ route('register') }}" class="btn btn-primary btn-sm">新規登録</a>
             @endauth
         </div>
     </div>
 </nav>
 
-<main class="container py-4">
+<main class="container py-5">
     @if (session('success'))
-        <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
             {{ session('success') }}
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     @endif
     @if (session('error'))
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
             {{ session('error') }}
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>

--- a/src/resources/views/layouts/guest.blade.php
+++ b/src/resources/views/layouts/guest.blade.php
@@ -6,15 +6,18 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name', '掲示板') }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/app.css" rel="stylesheet">
 </head>
-<body class="bg-light">
-    <div class="min-vh-100 d-flex align-items-center justify-content-center">
+<body class="guest-bg">
+    <div class="min-vh-100 d-flex align-items-center justify-content-center py-5">
         <div class="w-100" style="max-width: 420px;">
             <div class="text-center mb-4">
-                <a href="{{ route('posts.index') }}" class="text-decoration-none fs-4 fw-bold">掲示板</a>
+                <a href="{{ route('posts.index') }}" class="guest-brand">掲示板</a>
             </div>
-            <div class="card shadow-sm">
-                <div class="card-body p-4">
+            <div class="card guest-card">
+                <div class="card-body p-4 p-md-5">
                     {{ $slot }}
                 </div>
             </div>

--- a/src/resources/views/posts/create.blade.php
+++ b/src/resources/views/posts/create.blade.php
@@ -1,53 +1,57 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="card" style="max-width: 100%;">
-    <div class="card-body">
-        <h1 class="h5 mb-4">新規投稿</h1>
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <div class="card">
+            <div class="card-body p-4 p-md-5">
+                <h1 class="h5 fw-bold mb-4">新規投稿</h1>
 
-        <form method="POST" action="{{ route('posts.store') }}">
-            @csrf
+                <form method="POST" action="{{ route('posts.store') }}">
+                    @csrf
 
-            <div class="mb-3">
-                <label class="form-label">タイトル <span class="text-danger">*</span></label>
-                <input type="text" name="title"
-                       class="form-control @error('title') is-invalid @enderror"
-                       value="{{ old('title') }}" maxlength="255">
-                @error('title')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
+                    <div class="mb-3">
+                        <label class="form-label">タイトル <span class="text-danger">*</span></label>
+                        <input type="text" name="title"
+                               class="form-control @error('title') is-invalid @enderror"
+                               value="{{ old('title') }}" maxlength="255" autofocus>
+                        @error('title')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">カテゴリ</label>
+                        <select name="category_id" class="form-select @error('category_id') is-invalid @enderror">
+                            <option value="">選択なし</option>
+                            @foreach ($categories as $category)
+                                <option value="{{ $category->id }}"
+                                    {{ old('category_id') == $category->id ? 'selected' : '' }}>
+                                    {{ $category->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('category_id')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">本文 <span class="text-danger">*</span></label>
+                        <textarea name="body" rows="10"
+                                  class="form-control @error('body') is-invalid @enderror">{{ old('body') }}</textarea>
+                        @error('body')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary px-4">投稿する</button>
+                        <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary">キャンセル</a>
+                    </div>
+                </form>
             </div>
-
-            <div class="mb-3">
-                <label class="form-label">カテゴリ</label>
-                <select name="category_id" class="form-select @error('category_id') is-invalid @enderror">
-                    <option value="">選択なし</option>
-                    @foreach ($categories as $category)
-                        <option value="{{ $category->id }}"
-                            {{ old('category_id') == $category->id ? 'selected' : '' }}>
-                            {{ $category->name }}
-                        </option>
-                    @endforeach
-                </select>
-                @error('category_id')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-
-            <div class="mb-3">
-                <label class="form-label">本文 <span class="text-danger">*</span></label>
-                <textarea name="body" rows="8"
-                          class="form-control @error('body') is-invalid @enderror">{{ old('body') }}</textarea>
-                @error('body')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-
-            <div class="d-flex gap-2">
-                <button type="submit" class="btn btn-primary">投稿する</button>
-                <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary">キャンセル</a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
 @endsection

--- a/src/resources/views/posts/edit.blade.php
+++ b/src/resources/views/posts/edit.blade.php
@@ -1,54 +1,58 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="card" style="max-width: 640px;">
-    <div class="card-body">
-        <h1 class="h5 mb-4">投稿を編集</h1>
+<div class="row justify-content-center">
+    <div class="col-lg-8">
+        <div class="card">
+            <div class="card-body p-4 p-md-5">
+                <h1 class="h5 fw-bold mb-4">投稿を編集</h1>
 
-        <form method="POST" action="{{ route('posts.update', $post) }}">
-            @csrf
-            @method('PUT')
+                <form method="POST" action="{{ route('posts.update', $post) }}">
+                    @csrf
+                    @method('PUT')
 
-            <div class="mb-3">
-                <label class="form-label">タイトル <span class="text-danger">*</span></label>
-                <input type="text" name="title"
-                       class="form-control @error('title') is-invalid @enderror"
-                       value="{{ old('title', $post->title) }}" maxlength="255">
-                @error('title')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
+                    <div class="mb-3">
+                        <label class="form-label">タイトル <span class="text-danger">*</span></label>
+                        <input type="text" name="title"
+                               class="form-control @error('title') is-invalid @enderror"
+                               value="{{ old('title', $post->title) }}" maxlength="255">
+                        @error('title')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">カテゴリ</label>
+                        <select name="category_id" class="form-select @error('category_id') is-invalid @enderror">
+                            <option value="">選択なし</option>
+                            @foreach ($categories as $category)
+                                <option value="{{ $category->id }}"
+                                    {{ old('category_id', $post->category_id) == $category->id ? 'selected' : '' }}>
+                                    {{ $category->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('category_id')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">本文 <span class="text-danger">*</span></label>
+                        <textarea name="body" rows="10"
+                                  class="form-control @error('body') is-invalid @enderror">{{ old('body', $post->body) }}</textarea>
+                        @error('body')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary px-4">更新する</button>
+                        <a href="{{ route('posts.show', $post) }}" class="btn btn-outline-secondary">キャンセル</a>
+                    </div>
+                </form>
             </div>
-
-            <div class="mb-3">
-                <label class="form-label">カテゴリ</label>
-                <select name="category_id" class="form-select @error('category_id') is-invalid @enderror">
-                    <option value="">選択なし</option>
-                    @foreach ($categories as $category)
-                        <option value="{{ $category->id }}"
-                            {{ old('category_id', $post->category_id) == $category->id ? 'selected' : '' }}>
-                            {{ $category->name }}
-                        </option>
-                    @endforeach
-                </select>
-                @error('category_id')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-
-            <div class="mb-3">
-                <label class="form-label">本文 <span class="text-danger">*</span></label>
-                <textarea name="body" rows="8"
-                          class="form-control @error('body') is-invalid @enderror">{{ old('body', $post->body) }}</textarea>
-                @error('body')
-                    <div class="invalid-feedback">{{ $message }}</div>
-                @enderror
-            </div>
-
-            <div class="d-flex gap-2">
-                <button type="submit" class="btn btn-primary">更新する</button>
-                <a href="{{ route('posts.show', $post) }}" class="btn btn-outline-secondary">キャンセル</a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
 @endsection

--- a/src/resources/views/posts/index.blade.php
+++ b/src/resources/views/posts/index.blade.php
@@ -1,66 +1,76 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="h4 mb-0">投稿一覧</h1>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h4 fw-bold mb-0">投稿一覧</h1>
     @auth
-        <a href="{{ route('posts.create') }}" class="btn btn-primary btn-sm">新規投稿</a>
+        <a href="{{ route('posts.create') }}" class="btn btn-primary btn-sm px-3">+ 新規投稿</a>
     @endauth
 </div>
 
 {{-- 検索フィルタ --}}
-<form method="GET" action="{{ route('posts.index') }}" class="card card-body mb-4">
-    <div class="row g-2 align-items-end">
-        <div class="col-sm-4">
-            <label class="form-label small mb-1">カテゴリ</label>
-            <select name="category_id" class="form-select form-select-sm">
-                <option value="">すべて</option>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}"
-                        {{ request('category_id') == $category->id ? 'selected' : '' }}>
-                        {{ $category->name }}
-                    </option>
-                @endforeach
-            </select>
-        </div>
-        <div class="col-sm-5">
-            <label class="form-label small mb-1">タイトル検索</label>
-            <input type="text" name="title" class="form-control form-control-sm"
-                   placeholder="タイトルを検索..." value="{{ request('title') }}">
-        </div>
-        <div class="col-sm-3 d-flex gap-2">
-            <button type="submit" class="btn btn-primary btn-sm flex-fill">検索</button>
-            <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary btn-sm flex-fill">リセット</a>
-        </div>
+<div class="card mb-4">
+    <div class="card-body py-3">
+        <form method="GET" action="{{ route('posts.index') }}">
+            <div class="row g-2 align-items-end">
+                <div class="col-sm-4">
+                    <label class="form-label">カテゴリ</label>
+                    <select name="category_id" class="form-select form-select-sm">
+                        <option value="">すべて</option>
+                        @foreach ($categories as $category)
+                            <option value="{{ $category->id }}"
+                                {{ request('category_id') == $category->id ? 'selected' : '' }}>
+                                {{ $category->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-sm-5">
+                    <label class="form-label">タイトル検索</label>
+                    <input type="text" name="title" class="form-control form-control-sm"
+                           placeholder="タイトルを検索..." value="{{ request('title') }}">
+                </div>
+                <div class="col-sm-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary btn-sm flex-fill">検索</button>
+                    <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary btn-sm flex-fill">リセット</a>
+                </div>
+            </div>
+        </form>
     </div>
-</form>
+</div>
 
 {{-- 投稿一覧 --}}
 @forelse ($posts as $post)
-    <div class="card mb-3">
-        <div class="card-body">
-            <div class="d-flex justify-content-between align-items-start">
-                <h5 class="card-title mb-1">
-                    <a href="{{ route('posts.show', $post) }}" class="text-decoration-none">
-                        {{ $post->title }}
-                    </a>
-                </h5>
+    <div class="card card-hoverable mb-3">
+        <div class="card-body px-4 py-3">
+            <div class="d-flex justify-content-between align-items-start gap-2">
+                <div class="flex-grow-1">
+                    <h5 class="card-title mb-1 fw-semibold">
+                        <a href="{{ route('posts.show', $post) }}" class="text-decoration-none text-dark stretched-link">
+                            {{ $post->title }}
+                        </a>
+                    </h5>
+                    <p class="text-muted small mb-2">
+                        {{ $post->user->name }} &middot; {{ $post->created_at->format('Y/m/d H:i') }}
+                    </p>
+                </div>
                 @if ($post->category)
-                    <span class="badge bg-secondary ms-2 text-nowrap">{{ $post->category->name }}</span>
+                    <span class="badge bg-secondary text-nowrap">{{ $post->category->name }}</span>
                 @endif
             </div>
-            <p class="text-muted small mb-2">
-                {{ $post->user->name }} ・ {{ $post->created_at->format('Y/m/d H:i') }}
-            </p>
-            <div class="d-flex gap-3 text-muted small">
+            <div class="d-flex gap-3 small" style="color: #9ca3af;">
                 <span>♡ {{ $post->likes_count }}</span>
                 <span>💬 {{ $post->comments_count }}</span>
             </div>
         </div>
     </div>
 @empty
-    <p class="text-muted">投稿がありません。</p>
+    <div class="text-center py-5 text-muted">
+        <p class="mb-0">まだ投稿がありません。</p>
+    </div>
 @endforelse
 
-{{ $posts->links() }}
+<div class="mt-3">
+    {{ $posts->links() }}
+</div>
 @endsection

--- a/src/resources/views/posts/show.blade.php
+++ b/src/resources/views/posts/show.blade.php
@@ -5,21 +5,23 @@
     <a href="{{ route('posts.index') }}" class="btn btn-outline-secondary btn-sm">← 一覧に戻る</a>
 </div>
 
+{{-- 投稿カード --}}
 <div class="card mb-4">
-    <div class="card-body">
-        {{-- ヘッダー --}}
-        <div class="d-flex justify-content-between align-items-start mb-2">
+    <div class="card-body p-4 p-md-5">
+        <div class="d-flex justify-content-between align-items-start mb-3">
             <div>
-                <h1 class="h4 mb-1">{{ $post->title }}</h1>
-                <p class="text-muted small mb-0">
-                    {{ $post->user->name }} ・ {{ $post->created_at->format('Y/m/d H:i') }}
+                <h1 class="h3 fw-bold mb-2">{{ $post->title }}</h1>
+                <div class="d-flex align-items-center gap-2 text-muted small">
+                    <span>{{ $post->user->name }}</span>
+                    <span>&middot;</span>
+                    <span>{{ $post->created_at->format('Y/m/d H:i') }}</span>
                     @if ($post->category)
-                        ・ <span class="badge bg-secondary">{{ $post->category->name }}</span>
+                        <span class="badge bg-secondary">{{ $post->category->name }}</span>
                     @endif
-                </p>
+                </div>
             </div>
             @can('update', $post)
-                <div class="d-flex gap-2 ms-3">
+                <div class="d-flex gap-2 ms-3 flex-shrink-0">
                     <a href="{{ route('posts.edit', $post) }}" class="btn btn-outline-primary btn-sm">編集</a>
                     <form method="POST" action="{{ route('posts.destroy', $post) }}"
                           onsubmit="return confirm('この投稿を削除しますか？')">
@@ -31,39 +33,41 @@
         </div>
 
         <hr>
-        <p class="mb-0" style="white-space: pre-wrap;">{{ $post->body }}</p>
+        <p class="mb-0 lh-lg" style="white-space: pre-wrap;">{{ $post->body }}</p>
     </div>
 </div>
 
 {{-- いいねエリア --}}
-<div class="mb-4">
-    <span class="me-3">♡ {{ $post->likes->count() }} いいね</span>
+<div class="d-flex align-items-center gap-3 mb-5">
+    <span class="text-muted small">♡ {{ $post->likes->count() }} いいね</span>
     @auth
         <form method="POST" action="{{ route('likes.toggle', $post) }}" class="d-inline">
             @csrf
             @if ($post->likes->contains('user_id', auth()->id()))
-                <button class="btn btn-danger btn-sm">いいね済み</button>
+                <button class="btn btn-danger btn-sm px-3">♥ いいね済み</button>
             @else
-                <button class="btn btn-outline-danger btn-sm">いいね</button>
+                <button class="btn btn-outline-danger btn-sm px-3">♡ いいね</button>
             @endif
         </form>
     @endauth
 </div>
 
 {{-- コメントセクション --}}
-<h2 class="h5 mb-3">コメント（{{ $post->comments->count() }}件）</h2>
+<h2 class="h5 fw-bold mb-3">コメント <span class="text-muted fw-normal fs-6">（{{ $post->comments->count() }}件）</span></h2>
 
 @forelse ($post->comments as $comment)
     <div class="card mb-2">
-        <div class="card-body py-2">
+        <div class="card-body px-4 py-3">
             <div class="d-flex justify-content-between align-items-start">
-                <div>
-                    <span class="fw-semibold small">{{ $comment->user->name }}</span>
-                    <span class="text-muted small ms-2">{{ $comment->created_at->format('Y/m/d H:i') }}</span>
-                    <p class="mb-0 mt-1">{{ $comment->body }}</p>
+                <div class="flex-grow-1">
+                    <div class="d-flex align-items-center gap-2 mb-1">
+                        <span class="fw-semibold small">{{ $comment->user->name }}</span>
+                        <span class="text-muted small">{{ $comment->created_at->format('Y/m/d H:i') }}</span>
+                    </div>
+                    <p class="mb-0">{{ $comment->body }}</p>
                 </div>
                 @can('update', $comment)
-                    <div class="d-flex gap-2 ms-3 text-nowrap">
+                    <div class="d-flex gap-2 ms-3 flex-shrink-0">
                         <a href="{{ route('comments.edit', [$post, $comment]) }}"
                            class="btn btn-outline-secondary btn-sm">編集</a>
                         <form method="POST" action="{{ route('comments.destroy', [$post, $comment]) }}"
@@ -77,14 +81,14 @@
         </div>
     </div>
 @empty
-    <p class="text-muted small">コメントはまだありません。</p>
+    <p class="text-muted small mb-4">コメントはまだありません。</p>
 @endforelse
 
 {{-- コメント投稿フォーム --}}
 @auth
-    <div class="card mt-3">
-        <div class="card-body">
-            <h3 class="h6 mb-3">コメントを投稿</h3>
+    <div class="card mt-4">
+        <div class="card-body p-4">
+            <h3 class="h6 fw-bold mb-3">コメントを投稿</h3>
             <form method="POST" action="{{ route('comments.store', $post) }}">
                 @csrf
                 <div class="mb-3">
@@ -94,12 +98,12 @@
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
-                <button class="btn btn-primary btn-sm">コメントする</button>
+                <button class="btn btn-primary btn-sm px-3">コメントする</button>
             </form>
         </div>
     </div>
 @else
-    <p class="text-muted mt-3">
+    <p class="text-muted mt-4 small">
         コメントするには<a href="{{ route('login') }}">ログイン</a>が必要です。
     </p>
 @endauth


### PR DESCRIPTION
## Summary

- `public/css/app.css` を新規追加し、インディゴ配色・カスタムフォント・カード改善を一元管理
- Google Fonts（Inter + Noto Sans JP）を両レイアウトに追加
- 全 Blade ビュー（15 ファイル）のデザインを刷新

## 主な変更点

| 箇所 | 変更内容 |
|------|---------|
| カラー | デフォルト青 → インディゴ（`#4f46e5`）に統一 |
| フォント | Inter + Noto Sans JP を追加 |
| ナビバー | ダーク黒 → 白 + 細ボーダー + sticky |
| カード | ホバーで浮き上がるアニメーション追加（`card-hoverable`） |
| ゲスト画面 | グラジエント背景 + 大きめシャドウカード |
| フォーム画面 | ボタン全幅（`w-100`）で統一感を向上 |
| OTP/メール確認 | 絵文字アイコン追加でビジュアル強調 |
| バグ修正 | `confirm-password.blade.php` の削除済み Breeze コンポーネントを Bootstrap に書き換え |

## Test plan

- [x] `http://localhost:8080/posts` — 投稿一覧のデザイン確認
- [x] `/posts/create` — 投稿作成フォームの確認
- [x] `/login`・`/register` — 認証画面のデザイン確認
- [x] 新規登録 → OTP 入力フローの確認
- [x] `/password/confirm` — バグ修正の動作確認（エラーなく表示されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)