### PR TITLE
feat: アプリ名を「Korea x Japan Talk」に変更・KJ アイコンを追加

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME="Korea x Japan Talk"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/src/public/img/logo.svg
+++ b/src/public/img/logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <!-- Background -->
+  <rect width="64" height="64" rx="14" fill="#4f46e5"/>
+
+  <!-- KJ -->
+  <text
+    x="32" y="45"
+    font-family="Inter, Arial, sans-serif"
+    font-weight="700"
+    font-size="30"
+    fill="white"
+    text-anchor="middle"
+    letter-spacing="-1"
+  >KJ</text>
+</svg>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -16,7 +16,7 @@
 <nav class="navbar navbar-expand-lg sticky-top app-navbar">
     <div class="container">
         <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('posts.index') }}">
-            <img src="/img/logo.svg" width="28" height="28" alt="KJ">
+            <img src="/img/logo.svg" width="28" height="28" alt="Korea x Japan Talk ロゴ">
             Korea x Japan Talk
         </a>
         <div class="ms-auto d-flex align-items-center gap-2">

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>{{ config('app.name', '掲示板') }}</title>
+    <title>{{ config('app.name', 'Korea x Japan Talk') }}</title>
+    <link rel="icon" type="image/svg+xml" href="/img/logo.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
@@ -14,7 +15,10 @@
 
 <nav class="navbar navbar-expand-lg sticky-top app-navbar">
     <div class="container">
-        <a class="navbar-brand" href="{{ route('posts.index') }}">掲示板</a>
+        <a class="navbar-brand d-flex align-items-center gap-2" href="{{ route('posts.index') }}">
+            <img src="/img/logo.svg" width="28" height="28" alt="KJ">
+            Korea x Japan Talk
+        </a>
         <div class="ms-auto d-flex align-items-center gap-2">
             @auth
                 <span class="nav-user">{{ auth()->user()->name }}</span>

--- a/src/resources/views/layouts/guest.blade.php
+++ b/src/resources/views/layouts/guest.blade.php
@@ -15,7 +15,7 @@
     <div class="min-vh-100 d-flex align-items-center justify-content-center py-5">
         <div class="w-100" style="max-width: 420px;">
             <div class="text-center mb-4">
-                <img src="/img/logo.svg" width="52" height="52" alt="KJ" class="mb-2 d-block mx-auto">
+                <img src="/img/logo.svg" width="52" height="52" alt="Korea x Japan Talk ロゴ" class="mb-2 d-block mx-auto">
                 <a href="{{ route('posts.index') }}" class="guest-brand">Korea x Japan Talk</a>
             </div>
             <div class="card guest-card">

--- a/src/resources/views/layouts/guest.blade.php
+++ b/src/resources/views/layouts/guest.blade.php
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>{{ config('app.name', '掲示板') }}</title>
+    <title>{{ config('app.name', 'Korea x Japan Talk') }}</title>
+    <link rel="icon" type="image/svg+xml" href="/img/logo.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
@@ -14,7 +15,8 @@
     <div class="min-vh-100 d-flex align-items-center justify-content-center py-5">
         <div class="w-100" style="max-width: 420px;">
             <div class="text-center mb-4">
-                <a href="{{ route('posts.index') }}" class="guest-brand">掲示板</a>
+                <img src="/img/logo.svg" width="52" height="52" alt="KJ" class="mb-2 d-block mx-auto">
+                <a href="{{ route('posts.index') }}" class="guest-brand">Korea x Japan Talk</a>
             </div>
             <div class="card guest-card">
                 <div class="card-body p-4 p-md-5">


### PR DESCRIPTION
## Summary

- アプリ名を「Korea x Japan Talk」に変更（日韓情報交換掲示板として）
- KJ ロゴ（SVG）を新規作成してナビバー・ゲスト画面・favicon に適用

## 変更内容

| 対象 | 内容 |
|------|------|
| `.env.example` | `APP_NAME="Korea x Japan Talk"` に変更 |
| `public/img/logo.svg` | インディゴ背景 + KJ ホワイト太字の SVG アイコンを新規作成 |
| `layouts/app.blade.php` | favicon 追加・ナビバーブランドをアイコン + テキストに変更 |
| `layouts/guest.blade.php` | favicon 追加・ブランド部分に大きめアイコンを追加 |

## Test plan

- [ ] ブラウザのタブに KJ favicon と title `Korea x Japan Talk` が表示されること
- [ ] ナビバーに KJ アイコン + "Korea x Japan Talk" が表示されること
- [ ] ログイン・登録画面にもアイコンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)